### PR TITLE
Update AutoViz.ipynb to include Interact

### DIFF
--- a/doc/AutoViz.ipynb
+++ b/doc/AutoViz.ipynb
@@ -477,6 +477,7 @@
    ],
    "source": [
     "using Reactive\n",
+    "using Interact\n",
     "\n",
     "ticks = fps(framerate)\n",
     "timestamps = map(_ -> time(), ticks)\n",


### PR DESCRIPTION
The notebook previously failed to render the live driving video in the final cell. The solution was simply to run "using Interact" before trying to render.